### PR TITLE
Reservation 예약 기능 완성

### DIFF
--- a/src/main/java/com/core/miniproject/src/accommodation/domain/entity/Accommodation.java
+++ b/src/main/java/com/core/miniproject/src/accommodation/domain/entity/Accommodation.java
@@ -27,7 +27,7 @@ public class Accommodation {
     private Location location;
 
     //room_id 참조 관계 설정
-    @OneToMany(mappedBy = "accommodationId", cascade = CascadeType.REMOVE, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "accommodationId", cascade = CascadeType.REMOVE)
     @Column(name = "room_id")
     private List<Room> roomId;
 

--- a/src/main/java/com/core/miniproject/src/common/constant/IsVisited.java
+++ b/src/main/java/com/core/miniproject/src/common/constant/IsVisited.java
@@ -3,5 +3,7 @@ package com.core.miniproject.src.common.constant;
 public enum IsVisited {
 
     NOT_VISIT,
-    VISITED
+    VISIT_DATE,
+    VISITED,
+    OVERDUE
     }

--- a/src/main/java/com/core/miniproject/src/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/core/miniproject/src/common/response/BaseResponseStatus.java
@@ -29,6 +29,8 @@ public enum BaseResponseStatus {
     ACCOMMODATION_DOES_NOT_EXIST(false, BAD_REQUEST.value(), "해당 숙소가 존재하지 않습니다."),
     DUPLICATE_DISCOUNTRATE(false, BAD_REQUEST.value(), "할인율이 중복입니다"),
     DISCOUNT_NOT_FOUND(false, BAD_REQUEST.value(), "할인율 정보를 찾을 수 없습니다."),
+    ROOM_NOT_FOUND(false, BAD_REQUEST.value(), "객실 정보를 찾을 수 없습니다."),
+    NO_ROOMS_REMAINING(false, BAD_REQUEST.value(), "잔여 객실이 없습니다."),
     LOCATION_NOT_FOUND(false, BAD_REQUEST.value(), "지역 정보를 찾을 수 없습니다."),
     ERROR_SETTING_NUMBER_OF_GUEST(false, BAD_REQUEST.value(), "객실 인원 수 설정이 올바르지 않습니다."),
     SET_REQUIRED_INFORMATION(false, BAD_REQUEST.value(), "생성에 필요한 필수 정보가 누락되었습니다."),

--- a/src/main/java/com/core/miniproject/src/reservation/controller/ReservationController.java
+++ b/src/main/java/com/core/miniproject/src/reservation/controller/ReservationController.java
@@ -27,7 +27,7 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @PostMapping("/v1/reservation/insert")
-    public BaseResponse<ReservationInsertResponse> insertReservation(
+    public BaseResponse<ReservationInsertResponse> registerReservation(
             @RequestBody ReservationInsertRequest request,
             @JwtAuthentication MemberInfo memberInfo)
     {
@@ -35,7 +35,7 @@ public class ReservationController {
         log.info("Post Mapping - Create a new reservation - member_id : {}, member_email : {}, request : {}",
                 memberInfo.getId(), memberInfo.getEmail(), request);
 
-        return response(reservationService.insertReservation(request, memberInfo));
+        return response(reservationService.registerReservation(request, memberInfo));
     }
 
     @GetMapping("v1/reservation")

--- a/src/main/java/com/core/miniproject/src/reservation/model/dto/ReservationInsertRequest.java
+++ b/src/main/java/com/core/miniproject/src/reservation/model/dto/ReservationInsertRequest.java
@@ -14,10 +14,10 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class ReservationInsertRequest {
 
+    private Long roomId; // 예약을 하려는 객실 id값
     private String roomName;
     private LocalDate checkIn;
     private LocalDate checkOut;
-    private int price;
     private int fixedMember;
     private int maxedMember;
 

--- a/src/main/java/com/core/miniproject/src/reservation/model/dto/ReservationListResponse.java
+++ b/src/main/java/com/core/miniproject/src/reservation/model/dto/ReservationListResponse.java
@@ -2,6 +2,7 @@ package com.core.miniproject.src.reservation.model.dto;
 
 import com.core.miniproject.src.common.constant.IsVisited;
 import com.core.miniproject.src.reservation.model.entity.Reservation;
+import com.core.miniproject.src.room.domain.dto.RoomResponse;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -21,6 +22,7 @@ public class ReservationListResponse {
     private int fixedNumber;
     private int maxedNumber;
     private IsVisited isVisited;
+    private RoomResponse room;
 
     public static ReservationListResponse toClient(Reservation reservation) {
         return ReservationListResponse.builder()
@@ -32,6 +34,7 @@ public class ReservationListResponse {
                 .fixedNumber(reservation.getFixedNumber())
                 .maxedNumber(reservation.getMaxedNumber())
                 .isVisited(reservation.getIsVisited())
+                .room(RoomResponse.toClient(reservation.getRoom()))
                 .build();
     }
 }

--- a/src/main/java/com/core/miniproject/src/reservation/model/entity/Reservation.java
+++ b/src/main/java/com/core/miniproject/src/reservation/model/entity/Reservation.java
@@ -2,6 +2,7 @@ package com.core.miniproject.src.reservation.model.entity;
 
 import com.core.miniproject.src.common.constant.IsVisited;
 import com.core.miniproject.src.member.domain.entity.Member;
+import com.core.miniproject.src.room.domain.entity.Room;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -43,4 +44,7 @@ public class Reservation {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)) // 테스트 및 조작 유연성을 위한 외래키 제약조건 해제
     private Member member;
 
+    @ManyToOne
+    @JoinColumn(name = "room_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Room room;
 }

--- a/src/main/java/com/core/miniproject/src/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/core/miniproject/src/reservation/repository/ReservationRepository.java
@@ -1,13 +1,14 @@
 package com.core.miniproject.src.reservation.repository;
 
+import com.core.miniproject.src.common.constant.IsVisited;
 import com.core.miniproject.src.reservation.model.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -19,4 +20,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             where m.id = :memberId
             """)
     List<Reservation> findAllReservation(@Param("memberId") Long id);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update Reservation r
+            set r.isVisited = :isVisited
+            where r.checkIn = LOCAL_DATE
+            """)
+    int updateOnReservationDay(@Param("isVisited") IsVisited isVisited);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update Reservation r
+            set r.isVisited = :isVisited
+            where r.checkOut <= LOCAL_DATE
+            """)
+    int updateReservationOverDue(@Param("isVisited") IsVisited isVisited);
 }

--- a/src/main/java/com/core/miniproject/src/reservation/service/ReservationService.java
+++ b/src/main/java/com/core/miniproject/src/reservation/service/ReservationService.java
@@ -10,6 +10,8 @@ import com.core.miniproject.src.reservation.model.dto.ReservationInsertResponse;
 import com.core.miniproject.src.reservation.model.dto.ReservationListResponse;
 import com.core.miniproject.src.reservation.model.entity.Reservation;
 import com.core.miniproject.src.reservation.repository.ReservationRepository;
+import com.core.miniproject.src.room.domain.entity.Room;
+import com.core.miniproject.src.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,10 +26,11 @@ import static com.core.miniproject.src.common.response.BaseResponseStatus.*;
 public class ReservationService {
 
     private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
     private final ReservationRepository reservationRepository;
 
     @Transactional
-    public ReservationInsertResponse insertReservation(ReservationInsertRequest request, MemberInfo memberInfo) {
+    public ReservationInsertResponse registerReservation(ReservationInsertRequest request, MemberInfo memberInfo) {
 
         Member member = memberRepository.findByMemberEmail(memberInfo.getEmail())
                 .orElseThrow(() -> new BaseException(EMAIL_NOT_FOUND));
@@ -40,30 +43,50 @@ public class ReservationService {
     private Reservation getReservationFromRequest(ReservationInsertRequest request, Member member) {
         insertReservationValidate(request);
 
+        Room room = roomRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new BaseException(ROOM_NOT_FOUND));
+
+        // 검색을 했을 때 해당 객실에 예약 내역이 있으면 roomCount -1 이외의 날짜에는 roomCount가 초기상태
+
+        if(room.getRoomCount() == 0) { // 해당 객실의 잔여 개수가 0
+            throw new BaseException(NO_ROOMS_REMAINING);
+        }
+
         return Reservation.builder()
                 .member(member)
                 .roomName(request.getRoomName())
                 .checkIn(request.getCheckIn())
                 .checkOut(request.getCheckOut())
-                .price(request.getPrice())
+                .price(room.getPrice())
                 .fixedNumber(request.getFixedMember())
                 .maxedNumber(request.getMaxedMember())
-                .isVisited(IsVisited.VISITED)
+                .isVisited(IsVisited.NOT_VISIT)
+                .room(room) // 연관관계 매핑
                 .build();
     }
 
+    @Transactional
     public List<ReservationListResponse> findAllReservation(MemberInfo memberInfo) {
 
         Member member = emailValidate(memberInfo);
+
+        isVisitValidate();
+
         List<Reservation> allReservation =
                 reservationRepository.findAllReservation(member.getId());
+
 
         return allReservation.stream()
                 .map(ReservationListResponse::toClient)
                 .collect(Collectors.toList());
     }
 
-    private void insertReservationValidate(ReservationInsertRequest request) {
+    private void isVisitValidate() {// 체크인 시간과 현재 날짜를 비교해 방문여부 전환
+        reservationRepository.updateReservationOverDue(IsVisited.OVERDUE);
+        reservationRepository.updateOnReservationDay(IsVisited.VISIT_DATE);
+    }
+
+    private void insertReservationValidate(ReservationInsertRequest request) { // 체크인 & 체크아웃 날짜 논리 검증
         if (request.getCheckIn().equals(request.getCheckOut()) ||
             request.getCheckOut().isBefore(request.getCheckIn())) {
 

--- a/src/main/java/com/core/miniproject/src/room/domain/entity/Room.java
+++ b/src/main/java/com/core/miniproject/src/room/domain/entity/Room.java
@@ -1,9 +1,12 @@
 package com.core.miniproject.src.room.domain.entity;
 
 import com.core.miniproject.src.accommodation.domain.entity.Accommodation;
+import com.core.miniproject.src.reservation.model.entity.Reservation;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Formula;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,5 +45,10 @@ public class Room {
 
     @Column(name = "price")
     private Integer price;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.REMOVE)
+    @Column(name = "reservation_id")
+    private List<Reservation> reservations;
+
 
 }

--- a/src/test/java/com/core/miniproject/src/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/core/miniproject/src/reservation/repository/ReservationRepositoryTest.java
@@ -3,6 +3,7 @@ package com.core.miniproject.src.reservation.repository;
 import com.core.miniproject.src.common.constant.IsVisited;
 import com.core.miniproject.src.member.domain.entity.Member;
 import com.core.miniproject.src.reservation.model.entity.Reservation;
+import com.core.miniproject.src.room.domain.entity.Room;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -34,6 +35,7 @@ public class ReservationRepositoryTest {
                 .maxedNumber(4)
                 .isVisited(IsVisited.VISITED)
                 .member(Member.builder().id(1L).build())
+                .room(Room.builder().id(1L).build())
                 .build();
 
         // when

--- a/src/test/java/com/core/miniproject/src/room/RoomServiceTest.java
+++ b/src/test/java/com/core/miniproject/src/room/RoomServiceTest.java
@@ -72,7 +72,7 @@ public class RoomServiceTest {
     void room_저장_성공() {
         // given
         RoomInsertRequest request =
-                new RoomInsertRequest("객실1", "객실정보1", 50, 2, 4, "이미지", 20000);
+                new RoomInsertRequest("객실1", "객실정보1", 50, 2, 4, "이미지", 30000);
 
         BDDMockito.given(accommodationRepository.findById(any())).willReturn(Optional.of(accommodation));
 


### PR DESCRIPTION
- room & reservation 간 일대다 양방향 관계 설정
- reservation 저장 & 조회시 room 정보도 함께 조회할 수 있도록 매핑
- reservation 조회시마다 checkIn & checkOut 시간과 현재 시간을 비교해 reservaion의 상태값 변경되도록 작성
- 기존 코드 변경에 따른 테스트 코드 수정 및 통과

## #️⃣연관된 이슈

> ex) #59 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> room & reservation 간 일대다 양방향 관계 설정
> reservation 저장 & 조회시 room 정보도 함께 조회할 수 있도록 매핑
> reservation 조회시마다 checkIn & checkOut 시간과 현재 시간을 비교해 reservaion의 상태값 변경되도록 작성
> 기존 코드 변경에 따른 테스트 코드 수정 및 통과

## 💬추가 사항

