### PR TITLE
Accommodation - MultipleBagFetchException 해결

### DIFF
--- a/src/main/java/com/core/miniproject/src/accommodation/domain/entity/Accommodation.java
+++ b/src/main/java/com/core/miniproject/src/accommodation/domain/entity/Accommodation.java
@@ -8,7 +8,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -28,9 +30,10 @@ public class Accommodation {
     private Location location;
 
     //room_id 참조 관계 설정
+    @Builder.Default
     @OneToMany(mappedBy = "accommodationId", cascade = CascadeType.REMOVE)
     @Column(name = "room_id")
-    private List<Room> roomId;
+    private Set<Room> roomId = new HashSet<>();;
 
     @Column(name="introduction")
     private String introduction;
@@ -44,7 +47,7 @@ public class Accommodation {
 
     @Builder.Default
     @OneToMany(mappedBy = "accommodation", cascade = CascadeType.REMOVE)
-    private List<Rate> rates = new ArrayList<>();
+    private Set<Rate> rates = new HashSet<>();
 
 //    @Formula("select min(rp.price) from room_price rp join room r on rp.room_id = r.room_id where r.accommodation_id = accommodation_id")
     @Column(name = "price")

--- a/src/main/java/com/core/miniproject/src/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/com/core/miniproject/src/accommodation/repository/AccommodationRepository.java
@@ -6,6 +6,7 @@ import com.core.miniproject.src.location.domain.entity.LocationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,15 +24,18 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     @Query("""
             SELECT a
             FROM Accommodation a
-            LEFT JOIN a.rates
-            LEFT JOIN a.images
+            LEFT JOIN FETCH a.roomId
+            LEFT JOIN FETCH a.rates
+            LEFT JOIN FETCH a.images
             """)
     List<Accommodation> getAllAccommodation();
 
     @Query("""
             select a
             from Accommodation a
-            LEFT JOIN a.rates
+            LEFT JOIN FETCH a.roomId
+            LEFT JOIN FETCH a.rates
+            LEFT JOIN FETCH a.images
             where a.id = ?1
             """)
     Optional<Accommodation> findByAccommodationId(Long id);
@@ -39,7 +43,9 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     @Query("""
             select a
             from Accommodation a
+            LEFT JOIN FETCH a.roomId
             LEFT JOIN FETCH a.rates
+            LEFT JOIN FETCH a.images
             where a.accommodationType = ?1
             """)
     List<Accommodation> findByAccommodationType(AccommodationType accommodationType);
@@ -47,7 +53,9 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     @Query("""
             select a
             from Accommodation a
+            LEFT JOIN FETCH a.roomId
             LEFT JOIN FETCH a.rates
+            LEFT JOIN FETCH a.images
             where a.location.locationName = ?1
             """)
     List<Accommodation> findByLocationType(LocationType locationType);
@@ -55,7 +63,9 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
     @Query("""
             select a
             from Accommodation a
-            LEFT JOIN a.rates
+            LEFT JOIN FETCH a.roomId
+            LEFT JOIN FETCH a.rates
+            LEFT JOIN FETCH a.images
             where a.accommodationType = ?1
             and a.location.locationName = ?2
             """)
@@ -63,9 +73,11 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
 
     @Query(""" 
        select a
-       from Accommodation a 
+       from Accommodation a
        join Room r on a.id=r.accommodationId.id
        LEFT JOIN FETCH a.rates
+       LEFT JOIN FETCH a.roomId
+       LEFT JOIN FETCH a.images
        where a.location.locationName=?1
        and r.fixedMember=?2
        """)

--- a/src/main/java/com/core/miniproject/src/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/core/miniproject/src/accommodation/service/AccommodationService.java
@@ -140,7 +140,7 @@ public class AccommodationService {
 
     public AccommodationResponse getAccommodationDetail(Long accommodationId) {
 
-        Accommodation accommodation = accommodationRepository.findById(accommodationId)
+        Accommodation accommodation = accommodationRepository.findByAccommodationId(accommodationId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.ACCOMMODATION_DOES_NOT_EXIST));
 
         return AccommodationResponse.toClient(accommodation);


### PR DESCRIPTION
fetch join을 2개이상 사용하는 과정에서 카테시안 곱으로 인해 영속성 컨텍스트 내 데이터 매핑 문제가 발생하는 MultipleBagFetchException을 Accommodation과 연관된 하위 엔티티의 자료구조를 중복을 보장하지 않는 HashSet으로 변경함으로써 카테시안 곱을 방지해 매핑 issue를 해결

## #️⃣연관된 이슈

> ex) #71 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
>  fetch join으로 가져오는 엔티티가 두개이상으로 늘면서 카테시안 곱으로 인해 데이터 매핑에 문제가 생기는 MultipleBagFetchException 발생
> Accommodation의 하위 테이블 자료구조를 list가 아닌 HashSet으로 변경(중복을 허용하지 않는 자료구조를 사용함으로써 카테시안 곱 발생 방지)
> 다수 fetch join을 사용하는 쿼리문으로 전환 후 기능 테스트 성공

## 💬추가 사항
> fetch join을 2개이상 사용하는 과정에서 데이터 중복으로 인한 카테시안 곱이 발생. 이로인해 컨텍스트 내에서 데이터 매핑을 원활히 수행하지 못해 문제가 발생하는 MultipleBagFetchException이 발생함 issue 해결을 위해 Accommodation과 연관된 하위 엔티티의 자료구조를 중복을 보장하지 않는 HashSet으로 변경함으로써 카테시안 곱을 방지해 매핑 issue를 해결함
