### PR TITLE
JWT 예외처리를 위한 entrypoint 클래스 추가 및 보안 필터에 적용, refreshToken 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,21 +2,21 @@ name: Backend Server Deploy to AWS EC2
 
 on:
   push:
-    branches: [develop]
+    branches: [ develop ]
 
 env:
   PROJECT_NAME: KDT_BE7_Mini-Project
   BUCKET_NAME: accommodation-cicd-bucket
   CODE_DEPLOY_APP_NAME: accommodaionCICD
   DEPLOYMENT_GROUP_NAME: cicd_codeDeploy
-  
+
 jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
@@ -26,7 +26,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         shell: bash
-      
+
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+
       - name: Build and Test with Gradle
         run: ./gradlew clean build -x test
         shell: bash

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// docs
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 

--- a/src/main/java/com/core/miniproject/src/accommodation/controller/AccommodationPublicController.java
+++ b/src/main/java/com/core/miniproject/src/accommodation/controller/AccommodationPublicController.java
@@ -22,7 +22,6 @@ public class AccommodationPublicController {
 
     private final AccommodationService accommodationService;
 
-
     @GetMapping("/v1/accommodation")
     public BaseResponse<List<AccommodationResponse>> findAll(
             @RequestParam(name = "checkIn", required = false) LocalDate checkIn,
@@ -35,7 +34,6 @@ public class AccommodationPublicController {
 
         return BaseResponse.response(responses);
     }
-
 
     @GetMapping("/v1/accommodation/location/{location_type}")
     public BaseResponse<List<AccommodationResponse>> findByLocation(
@@ -83,5 +81,4 @@ public class AccommodationPublicController {
 
         return BaseResponse.response(response);
     }
-
 }

--- a/src/main/java/com/core/miniproject/src/common/config/RedisConfig.java
+++ b/src/main/java/com/core/miniproject/src/common/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.core.miniproject.src.common.config;
+
+import com.core.miniproject.src.common.security.jwt.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories(basePackages = "com.core.miniproject.src.common.security.jwt")
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, RefreshToken> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, RefreshToken> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(RefreshToken.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/core/miniproject/src/common/config/SecurityConfig.java
+++ b/src/main/java/com/core/miniproject/src/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.core.miniproject.src.common.config;
 
+import com.core.miniproject.src.common.exception.JwtAuthenticationEntryPoint;
 import com.core.miniproject.src.common.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -9,7 +10,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -20,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationEntryPoint entryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -47,7 +48,9 @@ public class SecurityConfig {
                 );
 
         http
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling
+                        (handler -> handler.authenticationEntryPoint(entryPoint));
 
         return http.build();
     }

--- a/src/main/java/com/core/miniproject/src/common/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/core/miniproject/src/common/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.core.miniproject.src.common.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationEntryPoint(
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) {
+
+        resolver.resolveException(request, response, null,
+                (Exception) request.getAttribute("exception"));
+    }
+}

--- a/src/main/java/com/core/miniproject/src/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/core/miniproject/src/common/response/BaseResponseStatus.java
@@ -44,6 +44,9 @@ public enum BaseResponseStatus {
 
     TYPE_MISMATCH(false, BAD_REQUEST.value(), "데이터 타입이 맞지 않습니다."),
     JSON_PARSE_ERROR(false, BAD_REQUEST.value(), "유효한 JSON 데이터가 아닙니다. 전달하는 데이터 타입을 확인해주세요."),
+
+    EXPIRED_ACCESSTOKEN(false, UNAUTHORIZED.value(), "토큰이 만료되었습니다."),
+
     /**
      * 500
      */

--- a/src/main/java/com/core/miniproject/src/common/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/core/miniproject/src/common/security/jwt/JwtTokenGenerator.java
@@ -1,8 +1,12 @@
 package com.core.miniproject.src.common.security.jwt;
 
 import com.core.miniproject.src.common.constant.Role;
+import com.core.miniproject.src.common.exception.BaseException;
+import com.core.miniproject.src.common.response.BaseResponseStatus;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -34,7 +38,7 @@ public class JwtTokenGenerator {
                 .build();
     }
 
-    private String createJwtToken(String email, Role role) { // 토큰 생성 메서드
+    public String createJwtToken(String email, Role role) { // 토큰 생성 메서드
 
         return Jwts.builder()
                 .claim("email", email)
@@ -45,19 +49,41 @@ public class JwtTokenGenerator {
                 .compact();
     }
 
+    public String createRefreshToken(String email) {
+
+        return Jwts.builder()
+                .claim("email", email)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + 3*24*60*60*1000))
+                .signWith(key)
+                .compact();
+    }
+
     public String getUserEmail(String token) {
 
-        Claims claims = extractCleam(token, key);
+        Claims claims = extractClaim(token, key);
 
         return claims.get("email", String.class);
     }
 
-    private Claims extractCleam(String token, SecretKey key) {
+    public boolean isExpired(String token) {
+        try {
+            Date expiredDate = extractClaim(token, key).getExpiration();
+
+            // 만료 시간이 현재 시간 이전이면 토큰이 만료됨
+            return expiredDate.before(new Date());
+
+        } catch (ExpiredJwtException e) {
+            throw new BaseException(BaseResponseStatus.EXPIRED_ACCESSTOKEN);
+        }
+
+    }
+
+    private Claims extractClaim(String token, SecretKey key) {
 
         return Jwts.parser()
                 .verifyWith(key).build()
                 .parseSignedClaims(token)
                 .getPayload();
     }
-
 }

--- a/src/main/java/com/core/miniproject/src/common/security/jwt/RefreshToken.java
+++ b/src/main/java/com/core/miniproject/src/common/security/jwt/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.core.miniproject.src.common.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 60*60*24*3)
+public class RefreshToken {
+
+    @Id
+    private String id;
+
+    private String refreshToken;
+
+    @Indexed
+    private String accessToken;
+}

--- a/src/main/java/com/core/miniproject/src/common/security/jwt/RefreshTokenService.java
+++ b/src/main/java/com/core/miniproject/src/common/security/jwt/RefreshTokenService.java
@@ -1,0 +1,46 @@
+package com.core.miniproject.src.common.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, RefreshToken> redisTemplate;
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
+    private static final String MEMBER_ID_KEY_PREFIX = "memberId:";
+
+    public void saveRefreshToken(RefreshToken refreshToken) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + refreshToken.getAccessToken();
+        long newTtl = TimeUnit.DAYS.toSeconds(3);
+        redisTemplate.opsForValue().set(key, refreshToken, newTtl, TimeUnit.SECONDS);
+    }
+
+    public RefreshToken getRefreshTokenByAccessToken(String accessToken) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_KEY_PREFIX + accessToken);
+    }
+
+//    public RefreshToken getRefreshTokenByMemberId(String memberId) {
+//        return redisTemplate.opsForValue().get(MEMBER_ID_KEY_PREFIX + memberId);
+//    }
+
+    public void updateRefreshToken(RefreshToken refreshToken, String oldAccessToken) {
+        String oldKey = REFRESH_TOKEN_KEY_PREFIX + oldAccessToken;
+        String newKey = REFRESH_TOKEN_KEY_PREFIX + refreshToken.getAccessToken();
+
+        Long ttl = redisTemplate.getExpire(oldKey);
+        long newTtl = TimeUnit.SECONDS.toSeconds(ttl);
+
+        redisTemplate.delete(oldKey);
+
+        redisTemplate.opsForValue().set(newKey, refreshToken, newTtl, TimeUnit.SECONDS);
+    }
+
+    public void deleteRefreshToken(RefreshToken refreshToken) {
+        redisTemplate.delete(refreshToken.getId());
+    }
+}

--- a/src/main/java/com/core/miniproject/src/member/controller/MemberController.java
+++ b/src/main/java/com/core/miniproject/src/member/controller/MemberController.java
@@ -1,9 +1,34 @@
 package com.core.miniproject.src.member.controller;
 
+import com.core.miniproject.src.common.response.BaseResponse;
+import com.core.miniproject.src.common.security.jwt.AccessToken;
+import com.core.miniproject.src.member.domain.dto.MemberLoginResponse;
+import com.core.miniproject.src.member.service.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.core.miniproject.src.common.response.BaseResponse.response;
+
+@Slf4j
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 @Tag(name = "회원 수정 & 삭제 api", description = "회원 관련 api - 보안 접근 필요")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/v1/member/token")
+    public BaseResponse<MemberLoginResponse> newToken(@RequestHeader(value = "Authorization") String authorization) {
+        log.info("[Post Mapping - 토큰 재발급입니다.");
+
+        AccessToken accessToken = memberService.newToken(authorization);
+
+        return response(MemberLoginResponse.toClient(accessToken));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,19 +44,25 @@ springdoc:
 jwt:
   access-token:
     secret-key: bab2ee005bf1daad5c736636d8b40184520f49df5d1b3303d923137af0b1dc95
-    access-expired: 600000
+    access-expired: 1800000
 
 ---
 spring:
   config:
     activate:
       on-profile: local
+
   h2:
     console:
       enabled: true
   datasource:
     hikari:
       jdbc-url: jdbc:h2:mem:testdb
+
+#  data:
+#    redis:
+#      host: localhost
+#      port: 6379
 
 ---
 logging:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #79 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> jwt 토큰 예외처리를 위한 entryPoint 작성
> redis 사용을 위한 의존성 설정, RedisConfig, RefreshToken 관련 클래스 설정
> entryPoint 시큐리티 config에 등록
> refreshToken 생성 로직 추가, 필터 상에 토큰 만료 및재발급 경우를 가정한 필터링 로직 추가
> 토큰 재발급 로직 구현, accessToken 만료 기간 연장(10분 -> 30분), git Action 활용한 redis 설치 스크립트 추가
## 💬추가 사항
> 배포버전 테스트가 필요합니다.
